### PR TITLE
Add PostHog (EU) analytics with consent gating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+.envrc

--- a/cookieBanner.js
+++ b/cookieBanner.js
@@ -61,16 +61,15 @@
     var text = document.createElement("p");
     text.style.margin = "0 0 0.9rem 0";
     var beforeLink = t(
-      "We use Microsoft Clarity to understand how visitors use this site. No tracking cookies are set until you accept. See ",
-      "We gebruiken Microsoft Clarity om te begrijpen hoe bezoekers deze site gebruiken. Er worden geen tracking cookies geplaatst totdat je akkoord gaat. Zie "
+      "We use analytics cookies to understand how visitors use this site and to improve it. No non-essential cookies are set until you accept. See our ",
+      "We gebruiken analytische cookies om te begrijpen hoe bezoekers deze site gebruiken en om de site te verbeteren. Er worden geen niet-essentiële cookies geplaatst totdat je akkoord gaat. Zie ons "
     );
-    var linkText = t("Clarity's cookie list", "Clarity's cookie-overzicht");
+    var linkText = t("Privacy policy", "Privacybeleid");
     var afterLink = t(" for details.", " voor details.");
 
     text.appendChild(document.createTextNode(beforeLink));
     var link = document.createElement("a");
-    link.href = "https://learn.microsoft.com/en-us/clarity/setup-and-installation/cookie-list";
-    link.target = "_blank";
+    link.href = "/privacy";
     link.rel = "noopener";
     link.textContent = linkText;
     link.style.cssText = "color:#12d5db;text-decoration:underline;";

--- a/index-nl.html
+++ b/index-nl.html
@@ -62,6 +62,7 @@
   }
   </script>
   <script src="/clarity.js"></script>
+  <script src="/posthog.js"></script>
   <script src="/cookieBanner.js" defer></script>
   <link rel="alternate" hreflang="en" href="https://cre8-it.nl/index.html" />
   <link rel="alternate" hreflang="nl" href="https://cre8-it.nl/index-nl.html" />

--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
   }
   </script>
   <script src="/clarity.js"></script>
+  <script src="/posthog.js"></script>
   <script src="/cookieBanner.js" defer></script>
   <link rel="alternate" hreflang="en" href="https://cre8-it.nl/index.html" />
   <link rel="alternate" hreflang="nl" href="https://cre8-it.nl/index-nl.html" />

--- a/posthog.js
+++ b/posthog.js
@@ -1,0 +1,70 @@
+// PostHog (EU) loader with explicit consent gating.
+// Mirrors clarity.js: nothing leaves the browser until the visitor accepts.
+// Loads AFTER clarity.js (which defines window.Cre8itConsent), and decorates
+// that object's grant/revoke so a single Accept/Decline drives both tools.
+(function () {
+  var PROJECT_TOKEN = "phc_zo2c9o5HEViLb2eajW5AP6AfMaXRRsU8gQoeNxSF7jfq"; // Cre8-it.nl (190730)
+  var API_HOST = "https://eu.i.posthog.com";
+  var STORAGE_KEY = "cre8it.cookieConsent";
+
+  var started = false;
+
+  function startPostHog() {
+    if (started) return;
+    started = true;
+    // Official posthog-js snippet (loads array stub, then the CDN bundle).
+    !function (t, e) {
+      var o, n, p, r;
+      e.__SV || (window.posthog = e, e._i = [], e.init = function (i, s, a) {
+        function g(t, e) {
+          var o = e.split("."); 2 == o.length && (t = t[o[0]], e = o[1]);
+          t[e] = function () { t.push([e].concat(Array.prototype.slice.call(arguments, 0))); };
+        }
+        (p = t.createElement("script")).type = "text/javascript", p.crossOrigin = "anonymous", p.async = !0,
+        p.src = s.api_host.replace(".i.posthog.com", "-assets.i.posthog.com") + "/static/array.js",
+        (r = t.getElementsByTagName("script")[0]).parentNode.insertBefore(p, r);
+        var u = e; for (void 0 !== a ? u = e[a] = [] : a = "posthog", u.people = u.people || [],
+        u.toString = function (t) { var e = "posthog"; return "posthog" !== a && (e += "." + a), t || (e += " (stub)"), e; },
+        u.people.toString = function () { return u.toString(1) + ".people (stub)"; },
+        o = "init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug getPageViewId captureTraceFeedback captureTraceMetric".split(" "), n = 0; n < o.length; n++) g(u, o[n]);
+        e._i.push([i, s, a]);
+      }, e.__SV = 1);
+    }(document, window.posthog || []);
+
+    window.posthog.init(PROJECT_TOKEN, {
+      api_host: API_HOST,
+      person_profiles: "identified_only",
+      capture_pageview: true,
+      capture_pageleave: true,
+      // Core Web Vitals → PostHog Web Vitals dashboard (project flag also on).
+      capture_performance: { web_vitals: true },
+      respect_dnt: true,
+      // Replay stays off — Microsoft Clarity owns session replay here.
+      disable_session_recording: true,
+    });
+  }
+
+  function stopPostHog() {
+    try { if (window.posthog && window.posthog.opt_out_capturing) window.posthog.opt_out_capturing(); }
+    catch (e) { /* ignore */ }
+  }
+
+  // Decorate the consent API clarity.js installed, so Accept/Decline drives both.
+  function wire() {
+    var existing = window.Cre8itConsent || { storageKey: STORAGE_KEY, grant: function () {}, revoke: function () {} };
+    var priorGrant = existing.grant;
+    var priorRevoke = existing.revoke;
+    window.Cre8itConsent = {
+      storageKey: existing.storageKey || STORAGE_KEY,
+      grant: function () { try { priorGrant && priorGrant(); } finally { startPostHog(); } },
+      revoke: function () { try { priorRevoke && priorRevoke(); } finally { stopPostHog(); } },
+    };
+  }
+
+  wire();
+
+  // Honor a previously stored decision on load.
+  try {
+    if (localStorage.getItem(STORAGE_KEY) === "accepted") startPostHog();
+  } catch (e) { /* localStorage unavailable — keep off */ }
+})();

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Privacy &amp; Cookies — Cre8-it</title>
+  <meta name="robots" content="index,follow" />
+  <link rel="canonical" href="https://www.cre8-it.nl/privacy" />
+  <style>
+    :root { color-scheme: light dark; }
+    body { font-family: "Open Sans", system-ui, -apple-system, sans-serif; line-height: 1.6;
+      max-width: 46rem; margin: 0 auto; padding: 2.5rem 1.25rem 4rem; color: #0f3541; background: #fff; }
+    h1 { font-size: 1.8rem; margin-bottom: .25rem; }
+    h2 { font-size: 1.15rem; margin-top: 2rem; }
+    a { color: #0b9aa0; }
+    .muted { color: #5b6b73; font-size: .9rem; }
+    table { border-collapse: collapse; width: 100%; margin-top: .5rem; font-size: .92rem; }
+    th, td { text-align: left; border-bottom: 1px solid #e2e8ec; padding: .5rem .4rem; vertical-align: top; }
+    .back { display: inline-block; margin-top: 2.5rem; }
+  </style>
+</head>
+<body>
+  <h1>Privacy &amp; Cookie Statement</h1>
+  <p class="muted">Cre8-it BV (i.o.) — Netherlands. Last updated: 2026-05-31.</p>
+
+  <p>
+    This page explains the cookies and analytics we use on <strong>cre8-it.nl</strong>.
+    We keep data collection to a minimum and load no non-essential cookies until you
+    accept them via the cookie banner. You can change your choice at any time by
+    clearing the <code>cre8it.cookieConsent</code> value in your browser, after which the
+    banner reappears.
+  </p>
+
+  <h2>Analytics &amp; measurement (consent required)</h2>
+  <p>These load only after you click <em>Accept</em>:</p>
+  <table>
+    <thead><tr><th>Service</th><th>Purpose</th><th>Provider &amp; region</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>PostHog</td>
+        <td>Product &amp; web analytics, Core Web Vitals (page performance). IP addresses are anonymised.</td>
+        <td>PostHog — EU cloud (Frankfurt, Germany)</td>
+      </tr>
+      <tr>
+        <td>Microsoft Clarity</td>
+        <td>Aggregated, anonymised session heatmaps to understand page usage.</td>
+        <td>Microsoft</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Essential / operational (no consent needed)</h2>
+  <p>
+    We use error- and performance-monitoring (Sentry and New Relic) strictly to keep
+    the site working and to diagnose faults. These do not build advertising profiles.
+  </p>
+
+  <h2>Your rights</h2>
+  <p>
+    Under the GDPR you may request access to, correction of, or deletion of your
+    personal data, and you may withdraw consent at any time. Contact
+    <a href="mailto:info@cre8-it.nl">info@cre8-it.nl</a>.
+  </p>
+
+  <p class="muted">
+    Dit privacy- en cookiebeleid is ook van toepassing op Nederlandse bezoekers.
+    Analytische cookies (PostHog, Microsoft Clarity) worden pas geplaatst nadat je
+    op <em>Accepteren</em> klikt. Voor vragen of verzoeken:
+    <a href="mailto:info@cre8-it.nl">info@cre8-it.nl</a>.
+  </p>
+
+  <a class="back" href="/">&larr; Back to cre8-it.nl</a>
+</body>
+</html>


### PR DESCRIPTION
## What

Adds PostHog product analytics + Core Web Vitals to cre8-it.nl, layered on top of the existing cookie-consent flow (which already gates Microsoft Clarity).

## Changes
- **posthog.js** (new): consent-gated loader. Decorates `window.Cre8itConsent` so one Accept/Decline drives both Clarity and PostHog. Web vitals on, session replay off (Clarity owns replay). EU cloud (project 190730).
- **index.html / index-nl.html**: load `/posthog.js` after clarity.js, before cookieBanner.js (so the consent decoration is registered before the banner can fire).
- **cookieBanner.js**: generic wording + link to `/privacy` (no longer names a single vendor, since two analytics tools now load).
- **privacy/index.html** (new): privacy & cookie statement documenting PostHog + Clarity, EU hosting, IP anonymisation.
- **.gitignore**: add `.envrc`.

## Notes
- Built on top of current `main` (the existing gated clarity.js + cookieBanner.js are untouched except the banner copy).
- `vite build` passes; all three JS files pass `node --check`.
- PostHog public ingestion key (phc_) is embedded by design — write-only, safe in client code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)